### PR TITLE
Fix for init method declared on a Controller.

### DIFF
--- a/src/monocle.coffee
+++ b/src/monocle.coffee
@@ -74,7 +74,7 @@ class Module
         setTimeout(@proxy(method), timeout || 0)
 
     constructor: ->
-        @init?(args...)
+        @init?(arguments)
 
 # Globals
 Monocle = @Monocle = {}


### PR DESCRIPTION
If I put an "init" method (an alias for constructor) declared on my Controller it throws the following error:
"Uncaught ReferenceError: args is not defined". Not anymore. :)
